### PR TITLE
Proof of innocence

### DIFF
--- a/src/circuits/mod.rs
+++ b/src/circuits/mod.rs
@@ -1,5 +1,6 @@
 pub mod balance;
 pub mod claim;
+pub mod proof_of_innocence;
 pub mod test_utils;
 pub mod validity;
 pub mod withdrawal;

--- a/src/circuits/proof_of_innocence/address_list.rs
+++ b/src/circuits/proof_of_innocence/address_list.rs
@@ -1,7 +1,7 @@
 use plonky2::{
     field::extension::Extendable,
     hash::hash_types::RichField,
-    iop::witness::WitnessWrite,
+    iop::{target::BoolTarget, witness::WitnessWrite},
     plonk::{
         circuit_builder::CircuitBuilder,
         config::{AlgebraicHasher, GenericConfig},
@@ -51,6 +51,10 @@ impl AddressMembershipProof {
         let generic_address = GenericAddress::from_address(address);
         self.0.verify(generic_address.data, root)
     }
+
+    pub fn is_included(&self) -> bool {
+        self.0.is_included
+    }
 }
 
 impl AddressMembershipProofTarget {
@@ -88,5 +92,9 @@ impl AddressMembershipProofTarget {
         let generic_address = GenericAddressTarget::from_address(builder, address);
         self.0
             .verify::<F, C, D>(builder, generic_address.data, root);
+    }
+
+    pub fn is_included(&self) -> BoolTarget {
+        self.0.is_included
     }
 }

--- a/src/circuits/proof_of_innocence/address_list.rs
+++ b/src/circuits/proof_of_innocence/address_list.rs
@@ -31,9 +31,9 @@ pub struct AddressMembershipProof(MembershipProof);
 pub struct AddressMembershipProofTarget(MembershipProofTarget);
 
 impl AddressListTree {
-    pub fn new(deny_list: &[Address]) -> anyhow::Result<Self> {
+    pub fn new(address_list: &[Address]) -> anyhow::Result<Self> {
         let mut tree = IndexedMerkleTree::new(ADDRESS_LIST_TREE_HEIGHT);
-        for address in deny_list {
+        for address in address_list {
             let generic_address = GenericAddress::from_address(*address);
             tree.insert(generic_address.data, 0)?;
         }

--- a/src/circuits/proof_of_innocence/address_list.rs
+++ b/src/circuits/proof_of_innocence/address_list.rs
@@ -1,0 +1,92 @@
+use plonky2::{
+    field::extension::Extendable,
+    hash::hash_types::RichField,
+    iop::witness::WitnessWrite,
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        config::{AlgebraicHasher, GenericConfig},
+    },
+};
+
+use crate::{
+    common::generic_address::{GenericAddress, GenericAddressTarget},
+    constants::ADDRESS_LIST_TREE_HEIGHT,
+    ethereum_types::address::{Address, AddressTarget},
+    utils::{
+        poseidon_hash_out::{PoseidonHashOut, PoseidonHashOutTarget},
+        trees::indexed_merkle_tree::{
+            membership::{MembershipProof, MembershipProofTarget},
+            IndexedMerkleTree,
+        },
+    },
+};
+
+pub struct AddressListTree(IndexedMerkleTree);
+pub struct AddressMembershipProof(MembershipProof);
+pub struct AddressMembershipProofTarget(MembershipProofTarget);
+
+impl AddressListTree {
+    pub fn new(deny_list: &[Address]) -> anyhow::Result<Self> {
+        let mut tree = IndexedMerkleTree::new(ADDRESS_LIST_TREE_HEIGHT);
+        for address in deny_list {
+            let generic_address = GenericAddress::from_address(*address);
+            tree.insert(generic_address.data, 0)?;
+        }
+        Ok(Self(tree))
+    }
+
+    pub fn get_root(&self) -> PoseidonHashOut {
+        self.0.get_root()
+    }
+
+    pub fn prove_membership(&self, address: Address) -> AddressMembershipProof {
+        let generic_address = GenericAddress::from_address(address);
+        let proof = self.0.prove_membership(generic_address.data);
+        AddressMembershipProof(proof)
+    }
+}
+
+impl AddressMembershipProof {
+    pub fn verify(&self, address: Address, root: PoseidonHashOut) -> anyhow::Result<()> {
+        let generic_address = GenericAddress::from_address(address);
+        self.0.verify(generic_address.data, root)
+    }
+}
+
+impl AddressMembershipProofTarget {
+    pub fn new<F: RichField + Extendable<D>, const D: usize>(
+        builder: &mut CircuitBuilder<F, D>,
+        is_checked: bool,
+    ) -> Self {
+        AddressMembershipProofTarget(MembershipProofTarget::new(
+            builder,
+            ADDRESS_LIST_TREE_HEIGHT,
+            is_checked,
+        ))
+    }
+
+    pub fn set_witness<F: RichField, W: WitnessWrite<F>>(
+        &self,
+        witness: &mut W,
+        value: &AddressMembershipProof,
+    ) {
+        self.0.set_witness(witness, &value.0)
+    }
+
+    pub fn verify<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F> + 'static,
+        const D: usize,
+    >(
+        &self,
+        builder: &mut CircuitBuilder<F, D>,
+        address: AddressTarget,
+        root: PoseidonHashOutTarget,
+    ) where
+        <C as GenericConfig<D>>::Hasher: AlgebraicHasher<F>,
+    {
+        let generic_address = GenericAddressTarget::from_address(builder, address);
+        self.0
+            .verify::<F, C, D>(builder, generic_address.data, root);
+    }
+}

--- a/src/circuits/proof_of_innocence/address_list.rs
+++ b/src/circuits/proof_of_innocence/address_list.rs
@@ -1,5 +1,5 @@
 use plonky2::{
-    field::extension::Extendable,
+    field::{extension::Extendable, types::Field},
     hash::hash_types::RichField,
     iop::{target::BoolTarget, witness::WitnessWrite},
     plonk::{
@@ -21,8 +21,13 @@ use crate::{
     },
 };
 
+#[derive(Debug, Clone)]
 pub struct AddressListTree(IndexedMerkleTree);
+
+#[derive(Debug, Clone)]
 pub struct AddressMembershipProof(MembershipProof);
+
+#[derive(Debug, Clone)]
 pub struct AddressMembershipProofTarget(MembershipProofTarget);
 
 impl AddressListTree {
@@ -69,7 +74,7 @@ impl AddressMembershipProofTarget {
         ))
     }
 
-    pub fn set_witness<F: RichField, W: WitnessWrite<F>>(
+    pub fn set_witness<F: Field, W: WitnessWrite<F>>(
         &self,
         witness: &mut W,
         value: &AddressMembershipProof,

--- a/src/circuits/proof_of_innocence/innocence_circuit.rs
+++ b/src/circuits/proof_of_innocence/innocence_circuit.rs
@@ -1,8 +1,32 @@
-use plonky2::iop::target::{BoolTarget, Target};
-
-use crate::utils::poseidon_hash_out::{
-    PoseidonHashOut, PoseidonHashOutTarget, POSEIDON_HASH_OUT_LEN,
+use hashbrown::HashMap;
+use plonky2::{
+    field::{extension::Extendable, types::PrimeField64},
+    gates::noop::NoopGate,
+    hash::hash_types::RichField,
+    iop::{
+        target::{BoolTarget, Target},
+        witness::{PartialWitness, WitnessWrite as _},
+    },
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitTarget},
+        config::{AlgebraicHasher, GenericConfig},
+        proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
+    },
+    recursion::dummy_circuit::cyclic_base_proof,
 };
+
+use crate::{
+    common::trees::nullifier_tree::NullifierTree,
+    constants::CYCLIC_CIRCUIT_PADDING_DEGREE,
+    utils::{
+        conversion::ToU64,
+        cyclic::vd_vec_len,
+        poseidon_hash_out::{PoseidonHashOut, PoseidonHashOutTarget, POSEIDON_HASH_OUT_LEN},
+    },
+};
+
+use super::innocence_inner_target::{InnocenceInnerTarget, InnocenceInnerValue};
 
 pub const INNOCENCE_PUBLIC_INPUTS_LEN: usize = 1 + 3 * POSEIDON_HASH_OUT_LEN;
 
@@ -44,6 +68,10 @@ impl InnocencePublicInputs {
             nullifier_tree_root,
         }
     }
+
+    pub fn from_pis<F: PrimeField64>(pis: &[F]) -> Self {
+        Self::from_u64_slice(&pis[0..INNOCENCE_PUBLIC_INPUTS_LEN].to_u64_vec())
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -84,4 +112,145 @@ impl InnocencePublicInputsTarget {
             nullifier_tree_root,
         }
     }
+
+    pub fn from_pis(pis: &[Target]) -> Self {
+        Self::from_slice(&pis[0..INNOCENCE_PUBLIC_INPUTS_LEN])
+    }
+}
+
+pub struct InnocenceCircuit<F, C, const D: usize>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+{
+    is_first_step: BoolTarget,
+    inner_target: InnocenceInnerTarget,
+    prev_proof: ProofWithPublicInputsTarget<D>,
+    verifier_data_target: VerifierCircuitTarget,
+    data: CircuitData<F, C, D>,
+}
+
+impl<F, C, const D: usize> InnocenceCircuit<F, C, D>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F> + 'static,
+    C::Hasher: AlgebraicHasher<F>,
+{
+    pub fn new() -> Self {
+        let mut builder = CircuitBuilder::<F, D>::new(CircuitConfig::default());
+        let is_first_step = builder.add_virtual_bool_target_safe();
+        let is_not_first_step = builder.not(is_first_step);
+        let inner_target = InnocenceInnerTarget::new::<F, C, D>(&mut builder, true);
+        let pis = InnocencePublicInputsTarget {
+            use_allow_list: inner_target.use_allow_list,
+            allow_list_tree_root: inner_target.allow_list_tree_root,
+            deny_list_tree_root: inner_target.deny_list_tree_root,
+            nullifier_tree_root: inner_target.new_nullifier_tree_root,
+        };
+        builder.register_public_inputs(&pis.to_vec());
+
+        let common_data = common_data_for_innocence_circuit::<F, C, D>();
+        let verifier_data_target = builder.add_verifier_data_public_inputs();
+
+        let prev_proof = builder.add_virtual_proof_with_pis(&common_data);
+        builder
+            .conditionally_verify_cyclic_proof_or_dummy::<C>(
+                is_not_first_step,
+                &prev_proof,
+                &common_data,
+            )
+            .unwrap();
+        let prev_pis = InnocencePublicInputsTarget::from_pis(&prev_proof.public_inputs);
+
+        // connect
+        builder.connect(
+            prev_pis.use_allow_list.target,
+            inner_target.use_allow_list.target,
+        );
+        prev_pis
+            .allow_list_tree_root
+            .connect(&mut builder, inner_target.allow_list_tree_root);
+        prev_pis
+            .deny_list_tree_root
+            .connect(&mut builder, inner_target.deny_list_tree_root);
+        prev_pis
+            .nullifier_tree_root
+            .connect(&mut builder, inner_target.prev_nullifier_tree_root);
+
+        let initial_nullifier_tree_root = NullifierTree::new().get_root();
+        let initial_nullifier_tree_root_target =
+            PoseidonHashOutTarget::constant(&mut builder, initial_nullifier_tree_root);
+        prev_pis.nullifier_tree_root.conditional_assert_eq(
+            &mut builder,
+            initial_nullifier_tree_root_target,
+            is_first_step,
+        );
+
+        let (data, success) = builder.try_build_with_options::<C>(true);
+        assert_eq!(data.common, common_data);
+        assert!(success);
+
+        Self {
+            is_first_step,
+            inner_target,
+            prev_proof,
+            verifier_data_target,
+            data,
+        }
+    }
+
+    pub fn prove(
+        &self,
+        inner_value: &InnocenceInnerValue,
+        prev_proof: &Option<ProofWithPublicInputs<F, C, D>>,
+    ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
+        let mut pw = PartialWitness::<F>::new();
+        pw.set_verifier_data_target(&self.verifier_data_target, &self.data.verifier_only);
+        self.inner_target.set_witness(&mut pw, inner_value);
+        if prev_proof.is_none() {
+            let dummy_proof =
+                cyclic_base_proof(&self.data.common, &self.data.verifier_only, HashMap::new());
+            pw.set_bool_target(self.is_first_step, true);
+            pw.set_proof_with_pis_target(&self.prev_proof, &dummy_proof);
+        } else {
+            pw.set_bool_target(self.is_first_step, false);
+            pw.set_proof_with_pis_target(&self.prev_proof, prev_proof.as_ref().unwrap());
+        }
+        self.data.prove(pw)
+    }
+}
+
+fn common_data_for_innocence_circuit<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>() -> CommonCircuitData<F, D>
+where
+    C::Hasher: AlgebraicHasher<F>,
+{
+    let builder = CircuitBuilder::<F, D>::new(CircuitConfig::default());
+    let data = builder.build::<C>();
+
+    let mut builder = CircuitBuilder::<F, D>::new(CircuitConfig::default());
+    let proof = builder.add_virtual_proof_with_pis(&data.common);
+    let verifier_data = VerifierCircuitTarget {
+        constants_sigmas_cap: builder.add_virtual_cap(data.common.config.fri_config.cap_height),
+        circuit_digest: builder.add_virtual_hash(),
+    };
+    builder.verify_proof::<C>(&proof, &verifier_data, &data.common);
+    let data = builder.build::<C>();
+
+    let mut builder = CircuitBuilder::<F, D>::new(CircuitConfig::default());
+    let proof = builder.add_virtual_proof_with_pis(&data.common);
+    let verifier_data = VerifierCircuitTarget {
+        constants_sigmas_cap: builder.add_virtual_cap(data.common.config.fri_config.cap_height),
+        circuit_digest: builder.add_virtual_hash(),
+    };
+    builder.verify_proof::<C>(&proof, &verifier_data, &data.common);
+    while builder.num_gates() < 1 << CYCLIC_CIRCUIT_PADDING_DEGREE {
+        builder.add_gate(NoopGate, vec![]);
+    }
+    let mut common = builder.build::<C>().common;
+    common.num_public_inputs = INNOCENCE_PUBLIC_INPUTS_LEN + vd_vec_len(&common.config);
+    common
 }

--- a/src/circuits/proof_of_innocence/innocence_circuit.rs
+++ b/src/circuits/proof_of_innocence/innocence_circuit.rs
@@ -130,7 +130,7 @@ where
     inner_target: InnocenceInnerTarget,
     prev_proof: ProofWithPublicInputsTarget<D>,
     verifier_data_target: VerifierCircuitTarget,
-    data: CircuitData<F, C, D>,
+    pub data: CircuitData<F, C, D>,
 }
 
 impl<F, C, const D: usize> InnocenceCircuit<F, C, D>

--- a/src/circuits/proof_of_innocence/innocence_circuit.rs
+++ b/src/circuits/proof_of_innocence/innocence_circuit.rs
@@ -1,8 +1,87 @@
-use crate::utils::poseidon_hash_out::PoseidonHashOut;
+use plonky2::iop::target::{BoolTarget, Target};
 
+use crate::utils::poseidon_hash_out::{
+    PoseidonHashOut, PoseidonHashOutTarget, POSEIDON_HASH_OUT_LEN,
+};
+
+pub const INNOCENCE_PUBLIC_INPUTS_LEN: usize = 1 + 3 * POSEIDON_HASH_OUT_LEN;
+
+#[derive(Clone, Debug)]
 pub struct InnocencePublicInputs {
     pub use_allow_list: bool,
     pub allow_list_tree_root: PoseidonHashOut,
     pub deny_list_tree_root: PoseidonHashOut,
     pub nullifier_tree_root: PoseidonHashOut,
+}
+
+impl InnocencePublicInputs {
+    pub fn to_u64_vec(&self) -> Vec<u64> {
+        let vec = vec![self.use_allow_list as u64]
+            .into_iter()
+            .chain(self.allow_list_tree_root.to_u64_vec().into_iter())
+            .chain(self.deny_list_tree_root.to_u64_vec().into_iter())
+            .chain(self.nullifier_tree_root.to_u64_vec().into_iter())
+            .collect::<Vec<_>>();
+        assert_eq!(vec.len(), INNOCENCE_PUBLIC_INPUTS_LEN);
+        vec
+    }
+
+    pub fn from_u64_slice(slice: &[u64]) -> Self {
+        assert_eq!(slice.len(), INNOCENCE_PUBLIC_INPUTS_LEN);
+        let use_allow_list = slice[0] != 0;
+        let allow_list_tree_root =
+            PoseidonHashOut::from_u64_slice(&slice[1..1 + POSEIDON_HASH_OUT_LEN]);
+        let deny_list_tree_root = PoseidonHashOut::from_u64_slice(
+            &slice[1 + POSEIDON_HASH_OUT_LEN..1 + 2 * POSEIDON_HASH_OUT_LEN],
+        );
+        let nullifier_tree_root = PoseidonHashOut::from_u64_slice(
+            &slice[1 + 2 * POSEIDON_HASH_OUT_LEN..1 + 3 * POSEIDON_HASH_OUT_LEN],
+        );
+        Self {
+            use_allow_list,
+            allow_list_tree_root,
+            deny_list_tree_root,
+            nullifier_tree_root,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct InnocencePublicInputsTarget {
+    pub use_allow_list: BoolTarget,
+    pub allow_list_tree_root: PoseidonHashOutTarget,
+    pub deny_list_tree_root: PoseidonHashOutTarget,
+    pub nullifier_tree_root: PoseidonHashOutTarget,
+}
+
+impl InnocencePublicInputsTarget {
+    pub fn to_vec(&self) -> Vec<Target> {
+        let vec = vec![self.use_allow_list.target]
+            .into_iter()
+            .chain(self.allow_list_tree_root.to_vec().into_iter())
+            .chain(self.deny_list_tree_root.to_vec().into_iter())
+            .chain(self.nullifier_tree_root.to_vec().into_iter())
+            .collect::<Vec<_>>();
+        assert_eq!(vec.len(), INNOCENCE_PUBLIC_INPUTS_LEN);
+        vec
+    }
+
+    pub fn from_slice(slice: &[Target]) -> Self {
+        assert_eq!(slice.len(), INNOCENCE_PUBLIC_INPUTS_LEN);
+        let use_allow_list = BoolTarget::new_unsafe(slice[0]);
+        let allow_list_tree_root =
+            PoseidonHashOutTarget::from_slice(&slice[1..1 + POSEIDON_HASH_OUT_LEN]);
+        let deny_list_tree_root = PoseidonHashOutTarget::from_slice(
+            &slice[1 + POSEIDON_HASH_OUT_LEN..1 + 2 * POSEIDON_HASH_OUT_LEN],
+        );
+        let nullifier_tree_root = PoseidonHashOutTarget::from_slice(
+            &slice[1 + 2 * POSEIDON_HASH_OUT_LEN..1 + 3 * POSEIDON_HASH_OUT_LEN],
+        );
+        Self {
+            use_allow_list,
+            allow_list_tree_root,
+            deny_list_tree_root,
+            nullifier_tree_root,
+        }
+    }
 }

--- a/src/circuits/proof_of_innocence/innocence_circuit.rs
+++ b/src/circuits/proof_of_innocence/innocence_circuit.rs
@@ -1,0 +1,8 @@
+use crate::utils::poseidon_hash_out::PoseidonHashOut;
+
+pub struct InnocencePublicInputs {
+    pub use_allow_list: bool,
+    pub allow_list_tree_root: PoseidonHashOut,
+    pub deny_list_tree_root: PoseidonHashOut,
+    pub nullifier_tree_root: PoseidonHashOut,
+}

--- a/src/circuits/proof_of_innocence/innocence_inner_circuit.rs
+++ b/src/circuits/proof_of_innocence/innocence_inner_circuit.rs
@@ -1,11 +1,26 @@
+use plonky2::{
+    field::{extension::Extendable, types::Field},
+    hash::hash_types::RichField,
+    iop::{target::BoolTarget, witness::WitnessWrite},
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        config::{AlgebraicHasher, GenericConfig},
+    },
+};
+
 use crate::{
-    common::{deposit::Deposit, trees::nullifier_tree::NullifierInsertionProof},
-    ethereum_types::bytes32::Bytes32,
-    utils::poseidon_hash_out::PoseidonHashOut,
+    circuits::proof_of_innocence::address_list::AddressMembershipProofTarget,
+    common::{
+        deposit::{Deposit, DepositTarget},
+        trees::nullifier_tree::{NullifierInsertionProof, NullifierInsertionProofTarget},
+    },
+    ethereum_types::bytes32::{Bytes32, Bytes32Target},
+    utils::poseidon_hash_out::{PoseidonHashOut, PoseidonHashOutTarget},
 };
 
 use super::address_list::AddressMembershipProof;
 
+#[derive(Debug, Clone)]
 pub struct InnocenceInnerValue {
     pub use_allow_list: bool,
     pub allow_list_tree_root: PoseidonHashOut,
@@ -29,7 +44,7 @@ impl InnocenceInnerValue {
         allow_list_membership_proof: AddressMembershipProof,
         deny_list_membership_proof: AddressMembershipProof,
     ) -> anyhow::Result<Self> {
-        // prove allow list inclusion
+        // prove allow/deny list inclusion/exclusion
         allow_list_membership_proof
             .verify(deposit.depositor, allow_list_tree_root)
             .map_err(|e| {
@@ -62,5 +77,94 @@ impl InnocenceInnerValue {
             allow_list_membership_proof,
             deny_list_membership_proof,
         })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InnocenceInnerTarget {
+    pub use_allow_list: BoolTarget,
+    pub allow_list_tree_root: PoseidonHashOutTarget,
+    pub deny_list_tree_root: PoseidonHashOutTarget,
+    pub prev_nullifier_tree_root: PoseidonHashOutTarget,
+    pub new_nullifier_tree_root: PoseidonHashOutTarget,
+    pub deposit: DepositTarget,
+    pub nullifier_proof: NullifierInsertionProofTarget,
+    pub allow_list_membership_proof: AddressMembershipProofTarget,
+    pub deny_list_membership_proof: AddressMembershipProofTarget,
+}
+
+impl InnocenceInnerTarget {
+    pub fn new<F: RichField + Extendable<D>, C: GenericConfig<D, F = F> + 'static, const D: usize>(
+        builder: &mut CircuitBuilder<F, D>,
+        is_checked: bool,
+    ) -> Self
+    where
+        <C as GenericConfig<D>>::Hasher: AlgebraicHasher<F>,
+    {
+        let use_allow_list = builder.add_virtual_bool_target_safe();
+        let allow_list_tree_root = PoseidonHashOutTarget::new(builder);
+        let deny_list_tree_root = PoseidonHashOutTarget::new(builder);
+        let prev_nullifier_tree_root = PoseidonHashOutTarget::new(builder);
+        let deposit = DepositTarget::new(builder, is_checked);
+        let nullifier_proof = NullifierInsertionProofTarget::new(builder, is_checked);
+        let allow_list_membership_proof = AddressMembershipProofTarget::new(builder, is_checked);
+        let deny_list_membership_proof = AddressMembershipProofTarget::new(builder, is_checked);
+
+        // prove allow/deny list inclusion/exclusion
+        allow_list_membership_proof.verify::<F, C, D>(
+            builder,
+            deposit.depositor,
+            allow_list_tree_root,
+        );
+        let not_included_allow_list = builder.not(allow_list_membership_proof.is_included());
+        let use_allow_list_and_not_included_allow_list =
+            builder.and(use_allow_list, not_included_allow_list);
+        builder.assert_zero(use_allow_list_and_not_included_allow_list.target);
+
+        deny_list_membership_proof.verify::<F, C, D>(
+            builder,
+            deposit.depositor,
+            deny_list_tree_root,
+        );
+        builder.assert_zero(deny_list_membership_proof.is_included().target);
+
+        // prove transition of nullifier root
+        let nullifier_poseidon = deposit.poseidon_hash(builder);
+        let nullifier = Bytes32Target::from_hash_out(builder, nullifier_poseidon);
+        let new_nullifier_tree_root =
+            nullifier_proof.get_new_root::<F, C, D>(builder, prev_nullifier_tree_root, nullifier);
+
+        Self {
+            use_allow_list,
+            allow_list_tree_root,
+            deny_list_tree_root,
+            prev_nullifier_tree_root,
+            new_nullifier_tree_root,
+            deposit,
+            nullifier_proof,
+            allow_list_membership_proof,
+            deny_list_membership_proof,
+        }
+    }
+
+    pub fn set_witness<W: WitnessWrite<F>, F: Field>(
+        &self,
+        witness: &mut W,
+        value: &InnocenceInnerValue,
+    ) {
+        witness.set_bool_target(self.use_allow_list, value.use_allow_list);
+        self.allow_list_tree_root.set_witness(witness, value.allow_list_tree_root);
+        self.deny_list_tree_root.set_witness(witness, value.deny_list_tree_root);
+        self.prev_nullifier_tree_root
+            .set_witness(witness, value.prev_nullifier_tree_root);
+        self.new_nullifier_tree_root
+            .set_witness(witness, value.new_nullifier_tree_root);
+        self.deposit.set_witness(witness, &value.deposit);
+        self.nullifier_proof.set_witness(witness, &value.nullifier_proof);
+        self.allow_list_membership_proof
+            .set_witness(witness, &value.allow_list_membership_proof);
+        self.deny_list_membership_proof
+            .set_witness(witness, &value.deny_list_membership_proof);
+        
     }
 }

--- a/src/circuits/proof_of_innocence/innocence_inner_circuit.rs
+++ b/src/circuits/proof_of_innocence/innocence_inner_circuit.rs
@@ -1,0 +1,66 @@
+use crate::{
+    common::{deposit::Deposit, trees::nullifier_tree::NullifierInsertionProof},
+    ethereum_types::bytes32::Bytes32,
+    utils::poseidon_hash_out::PoseidonHashOut,
+};
+
+use super::address_list::AddressMembershipProof;
+
+pub struct InnocenceInnerValue {
+    pub use_allow_list: bool,
+    pub allow_list_tree_root: PoseidonHashOut,
+    pub deny_list_tree_root: PoseidonHashOut,
+    pub prev_nullifier_tree_root: PoseidonHashOut,
+    pub new_nullifier_tree_root: PoseidonHashOut,
+    pub deposit: Deposit,
+    pub nullifier_proof: NullifierInsertionProof,
+    pub allow_list_membership_proof: AddressMembershipProof,
+    pub deny_list_membership_proof: AddressMembershipProof,
+}
+
+impl InnocenceInnerValue {
+    pub fn new(
+        use_allow_list: bool,
+        allow_list_tree_root: PoseidonHashOut,
+        deny_list_tree_root: PoseidonHashOut,
+        prev_nullifier_tree_root: PoseidonHashOut,
+        deposit: Deposit,
+        nullifier_proof: NullifierInsertionProof,
+        allow_list_membership_proof: AddressMembershipProof,
+        deny_list_membership_proof: AddressMembershipProof,
+    ) -> anyhow::Result<Self> {
+        // prove allow list inclusion
+        allow_list_membership_proof
+            .verify(deposit.depositor, allow_list_tree_root)
+            .map_err(|e| {
+                anyhow::anyhow!("allow list membership proof verification failed: {}", e)
+            })?;
+        if use_allow_list && !allow_list_membership_proof.is_included() {
+            return Err(anyhow::anyhow!("depositor is not in the allow list"));
+        }
+        deny_list_membership_proof
+            .verify(deposit.depositor, deny_list_tree_root)
+            .map_err(|e| {
+                anyhow::anyhow!("deny list membership proof verification failed: {}", e)
+            })?;
+        if !deny_list_membership_proof.is_included() {
+            return Err(anyhow::anyhow!("depositor is in the deny list"));
+        }
+        // prove transition of nullifier root
+        let nullifier: Bytes32 = deposit.poseidon_hash().into();
+        let new_nullifier_tree_root = nullifier_proof
+            .get_new_root(prev_nullifier_tree_root, nullifier)
+            .map_err(|e| anyhow::anyhow!("Invalid nullifier merkle proof: {}", e))?;
+        Ok(Self {
+            use_allow_list,
+            allow_list_tree_root,
+            deny_list_tree_root,
+            prev_nullifier_tree_root,
+            new_nullifier_tree_root,
+            deposit,
+            nullifier_proof,
+            allow_list_membership_proof,
+            deny_list_membership_proof,
+        })
+    }
+}

--- a/src/circuits/proof_of_innocence/innocence_inner_target.rs
+++ b/src/circuits/proof_of_innocence/innocence_inner_target.rs
@@ -153,18 +153,20 @@ impl InnocenceInnerTarget {
         value: &InnocenceInnerValue,
     ) {
         witness.set_bool_target(self.use_allow_list, value.use_allow_list);
-        self.allow_list_tree_root.set_witness(witness, value.allow_list_tree_root);
-        self.deny_list_tree_root.set_witness(witness, value.deny_list_tree_root);
+        self.allow_list_tree_root
+            .set_witness(witness, value.allow_list_tree_root);
+        self.deny_list_tree_root
+            .set_witness(witness, value.deny_list_tree_root);
         self.prev_nullifier_tree_root
             .set_witness(witness, value.prev_nullifier_tree_root);
         self.new_nullifier_tree_root
             .set_witness(witness, value.new_nullifier_tree_root);
         self.deposit.set_witness(witness, &value.deposit);
-        self.nullifier_proof.set_witness(witness, &value.nullifier_proof);
+        self.nullifier_proof
+            .set_witness(witness, &value.nullifier_proof);
         self.allow_list_membership_proof
             .set_witness(witness, &value.allow_list_membership_proof);
         self.deny_list_membership_proof
             .set_witness(witness, &value.deny_list_membership_proof);
-        
     }
 }

--- a/src/circuits/proof_of_innocence/innocence_inner_target.rs
+++ b/src/circuits/proof_of_innocence/innocence_inner_target.rs
@@ -172,7 +172,7 @@ impl InnocenceInnerTarget {
 }
 
 #[cfg(test)]
-mod a {
+mod tests {
     use plonky2::{
         field::goldilocks_field::GoldilocksField,
         iop::witness::PartialWitness,

--- a/src/circuits/proof_of_innocence/innocence_processor.rs
+++ b/src/circuits/proof_of_innocence/innocence_processor.rs
@@ -1,0 +1,175 @@
+use std::collections::HashMap;
+
+use anyhow::bail;
+use plonky2::{
+    field::extension::Extendable,
+    hash::hash_types::RichField,
+    plonk::{
+        config::{AlgebraicHasher, GenericConfig},
+        proof::ProofWithPublicInputs,
+    },
+};
+
+use crate::{
+    circuits::proof_of_innocence::{
+        address_list::AddressListTree, innocence_inner_target::InnocenceInnerValue,
+    },
+    common::{
+        deposit::Deposit, private_state::FullPrivateState, trees::nullifier_tree::NullifierTree,
+    },
+    ethereum_types::{address::Address, bytes32::Bytes32},
+    utils::poseidon_hash_out::PoseidonHashOut,
+};
+
+use super::{
+    innocence_circuit::InnocenceCircuit,
+    innocence_wrap_circuit::{InnocenceWrapCircuit, InnocenceWrapPublicInputs},
+};
+
+pub struct InnocenceProcessor<F, C, const D: usize>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+{
+    innocence_circuit: InnocenceCircuit<F, C, D>,
+    innocence_wrap_circuit: InnocenceWrapCircuit<F, C, D>,
+}
+
+impl<F, C, const D: usize> InnocenceProcessor<F, C, D>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F> + 'static,
+    C::Hasher: AlgebraicHasher<F>,
+{
+    pub fn new() -> Self {
+        let innocence_circuit = InnocenceCircuit::new();
+        let innocence_wrap_circuit =
+            InnocenceWrapCircuit::new(&innocence_circuit.data.verifier_data());
+        Self {
+            innocence_circuit,
+            innocence_wrap_circuit,
+        }
+    }
+
+    pub fn prove(
+        &self,
+        allow_list: Option<&[Address]>,
+        deny_list: &[Address],
+        full_private_state: &FullPrivateState,
+        deposits: &[Deposit],
+    ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
+        let mut nullifier_map = HashMap::<Bytes32, Deposit>::new();
+        for deposit in deposits {
+            nullifier_map.insert(deposit.poseidon_hash().into(), deposit.clone());
+        }
+
+        let mut sorted_deposits = Vec::new();
+        for nullifier in full_private_state.nullifier_tree.nullifiers() {
+            if !nullifier_map.contains_key(&nullifier) {
+                bail!(
+                    "corresponding deposit not found for nullifier {}",
+                    nullifier
+                );
+            } else {
+                sorted_deposits.push(nullifier_map.get(&nullifier).unwrap());
+            }
+        }
+        if sorted_deposits.is_empty() {
+            bail!("at least one deposit is required");
+        }
+        // verification
+        let use_allow_list = allow_list.is_some();
+        {
+            let mut nullifier_tree = NullifierTree::new();
+            for deposit in &sorted_deposits {
+                if use_allow_list && !allow_list.unwrap().contains(&deposit.depositor) {
+                    bail!("depositor is not in the allow list");
+                }
+                if deny_list.contains(&deposit.depositor) {
+                    bail!("depositor is in the deny list");
+                }
+                let nullifier: Bytes32 = deposit.poseidon_hash().into();
+                nullifier_tree
+                    .prove_and_insert(nullifier)
+                    .map_err(|e| anyhow::anyhow!("Failed to prove and insert nullifier: {}", e))?;
+            }
+            if nullifier_tree.get_root() != full_private_state.nullifier_tree.get_root() {
+                bail!("Invalid nullifier tree root");
+            }
+        }
+
+        let allow_list_tree = AddressListTree::new(allow_list.unwrap_or_default())
+            .map_err(|e| anyhow::anyhow!("Failed to create allow list tree: {}", e))?;
+        let deny_list_tree = AddressListTree::new(deny_list)
+            .map_err(|e| anyhow::anyhow!("Failed to create deny list tree: {}", e))?;
+        let allow_list_tree_root = allow_list_tree.get_root();
+        let deny_list_tree_root = deny_list_tree.get_root();
+
+        let mut nullifier_tree = NullifierTree::new();
+        let mut innocence_proof = None;
+        for deposit in sorted_deposits {
+            let prev_nullifier_tree_root = nullifier_tree.get_root();
+            let nullifier_proof = nullifier_tree
+                .prove_and_insert(deposit.poseidon_hash().into())
+                .map_err(|e| anyhow::anyhow!("Failed to prove and insert nullifier: {}", e))?;
+            let allow_list_membership_proof = allow_list_tree.prove_membership(deposit.depositor);
+            let deny_list_membership_proof = deny_list_tree.prove_membership(deposit.depositor);
+            let value = InnocenceInnerValue::new(
+                use_allow_list,
+                allow_list_tree_root,
+                deny_list_tree_root,
+                prev_nullifier_tree_root,
+                deposit.clone(),
+                nullifier_proof,
+                allow_list_membership_proof,
+                deny_list_membership_proof,
+            )
+            .map_err(|e| anyhow::anyhow!("Failed to create innocence inner value: {}", e))?;
+            innocence_proof = Some(
+                self.innocence_circuit
+                    .prove(&value, &innocence_proof)
+                    .map_err(|e| anyhow::anyhow!("Failed to prove innocence circuit: {}", e))?,
+            );
+        }
+
+        let private_state = full_private_state.to_private_state();
+        let innocence_wrap_proof = self
+            .innocence_wrap_circuit
+            .prove(innocence_proof.as_ref().unwrap(), private_state)
+            .map_err(|e| anyhow::anyhow!("Failed to prove innocence wrap circuit: {}", e))?;
+
+        Ok(innocence_wrap_proof)
+    }
+
+    pub fn verify(
+        &self,
+        allow_list: Option<&[Address]>,
+        deny_list: &[Address],
+        private_commitment: PoseidonHashOut,
+        innocence_wrap_proof: &ProofWithPublicInputs<F, C, D>,
+    ) -> anyhow::Result<()> {
+        self.innocence_wrap_circuit
+            .verify(innocence_wrap_proof)
+            .map_err(|e| anyhow::anyhow!("Failed to verify innocence wrap circuit: {}", e))?;
+        let pis = InnocenceWrapPublicInputs::from_pis(&innocence_wrap_proof.public_inputs);
+        let use_allow_list = allow_list.is_some();
+        let allow_list_tree = AddressListTree::new(allow_list.unwrap_or_default()).unwrap();
+        let deny_list_tree = AddressListTree::new(deny_list).unwrap();
+        let allow_list_tree_root = allow_list_tree.get_root();
+        let deny_list_tree_root = deny_list_tree.get_root();
+
+        if pis.use_allow_list != use_allow_list {
+            bail!("use_allow_list is not equal to the expected value");
+        }
+        if pis.allow_list_tree_root != allow_list_tree_root {
+            bail!("allow_list_tree_root is not equal to the expected value");
+        }
+        if pis.deny_list_tree_root != deny_list_tree_root {
+            bail!("deny_list_tree_root is not equal to the expected value");
+        }
+        if pis.private_commitment != private_commitment {
+            bail!("private_commitment is not equal to the expected value");
+        }
+        Ok(())
+    }
+}

--- a/src/circuits/proof_of_innocence/innocence_wrap_circuit.rs
+++ b/src/circuits/proof_of_innocence/innocence_wrap_circuit.rs
@@ -1,7 +1,10 @@
 use plonky2::{
     field::{extension::Extendable, types::PrimeField64},
     hash::hash_types::RichField,
-    iop::{target::{BoolTarget, Target}, witness::{PartialWitness, WitnessWrite as _}},
+    iop::{
+        target::{BoolTarget, Target},
+        witness::{PartialWitness, WitnessWrite as _},
+    },
     plonk::{
         circuit_builder::CircuitBuilder,
         circuit_data::{CircuitConfig, CircuitData, VerifierCircuitData},
@@ -162,5 +165,9 @@ where
         pw.set_proof_with_pis_target(&self.innocence_proof, innocence_proof);
         self.private_state.set_witness(&mut pw, &private_state);
         self.data.prove(pw)
+    }
+
+    pub fn verify(&self, proof: &ProofWithPublicInputs<F, C, D>) -> anyhow::Result<()> {
+        self.data.verify(proof.clone())
     }
 }

--- a/src/circuits/proof_of_innocence/innocence_wrap_circuit.rs
+++ b/src/circuits/proof_of_innocence/innocence_wrap_circuit.rs
@@ -1,0 +1,166 @@
+use plonky2::{
+    field::{extension::Extendable, types::PrimeField64},
+    hash::hash_types::RichField,
+    iop::{target::{BoolTarget, Target}, witness::{PartialWitness, WitnessWrite as _}},
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{CircuitConfig, CircuitData, VerifierCircuitData},
+        config::{AlgebraicHasher, GenericConfig},
+        proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
+    },
+};
+
+use crate::{
+    common::private_state::{PrivateState, PrivateStateTarget},
+    utils::{
+        conversion::ToU64 as _,
+        poseidon_hash_out::{PoseidonHashOut, PoseidonHashOutTarget, POSEIDON_HASH_OUT_LEN},
+        recursively_verifiable::add_proof_target_and_verify_cyclic,
+    },
+};
+
+use super::innocence_circuit::InnocencePublicInputsTarget;
+
+pub const INNOCENCE_WRAP_PUBLIC_INPUTS_LEN: usize = 1 + 3 * POSEIDON_HASH_OUT_LEN;
+
+#[derive(Clone, Debug)]
+pub struct InnocenceWrapPublicInputs {
+    pub use_allow_list: bool,
+    pub allow_list_tree_root: PoseidonHashOut,
+    pub deny_list_tree_root: PoseidonHashOut,
+    pub private_commitment: PoseidonHashOut,
+}
+
+impl InnocenceWrapPublicInputs {
+    pub fn to_u64_vec(&self) -> Vec<u64> {
+        let vec = vec![self.use_allow_list as u64]
+            .into_iter()
+            .chain(self.allow_list_tree_root.to_u64_vec().into_iter())
+            .chain(self.deny_list_tree_root.to_u64_vec().into_iter())
+            .chain(self.private_commitment.to_u64_vec().into_iter())
+            .collect::<Vec<_>>();
+        assert_eq!(vec.len(), INNOCENCE_WRAP_PUBLIC_INPUTS_LEN);
+        vec
+    }
+
+    pub fn from_u64_slice(slice: &[u64]) -> Self {
+        assert_eq!(slice.len(), INNOCENCE_WRAP_PUBLIC_INPUTS_LEN);
+        let use_allow_list = slice[0] != 0;
+        let allow_list_tree_root =
+            PoseidonHashOut::from_u64_slice(&slice[1..1 + POSEIDON_HASH_OUT_LEN]);
+        let deny_list_tree_root = PoseidonHashOut::from_u64_slice(
+            &slice[1 + POSEIDON_HASH_OUT_LEN..1 + 2 * POSEIDON_HASH_OUT_LEN],
+        );
+        let private_commitment = PoseidonHashOut::from_u64_slice(
+            &slice[1 + 2 * POSEIDON_HASH_OUT_LEN..1 + 3 * POSEIDON_HASH_OUT_LEN],
+        );
+        Self {
+            use_allow_list,
+            allow_list_tree_root,
+            deny_list_tree_root,
+            private_commitment,
+        }
+    }
+
+    pub fn from_pis<F: PrimeField64>(pis: &[F]) -> Self {
+        Self::from_u64_slice(&pis[0..INNOCENCE_WRAP_PUBLIC_INPUTS_LEN].to_u64_vec())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct InnocenceWrapPublicInputsTarget {
+    pub use_allow_list: BoolTarget,
+    pub allow_list_tree_root: PoseidonHashOutTarget,
+    pub deny_list_tree_root: PoseidonHashOutTarget,
+    pub private_commitment: PoseidonHashOutTarget,
+}
+
+impl InnocenceWrapPublicInputsTarget {
+    pub fn to_vec(&self) -> Vec<Target> {
+        let vec = vec![self.use_allow_list.target]
+            .into_iter()
+            .chain(self.allow_list_tree_root.to_vec().into_iter())
+            .chain(self.deny_list_tree_root.to_vec().into_iter())
+            .chain(self.private_commitment.to_vec().into_iter())
+            .collect::<Vec<_>>();
+        assert_eq!(vec.len(), INNOCENCE_WRAP_PUBLIC_INPUTS_LEN);
+        vec
+    }
+
+    pub fn from_slice(slice: &[Target]) -> Self {
+        assert_eq!(slice.len(), INNOCENCE_WRAP_PUBLIC_INPUTS_LEN);
+        let use_allow_list = BoolTarget::new_unsafe(slice[0]);
+        let allow_list_tree_root =
+            PoseidonHashOutTarget::from_slice(&slice[1..1 + POSEIDON_HASH_OUT_LEN]);
+        let deny_list_tree_root = PoseidonHashOutTarget::from_slice(
+            &slice[1 + POSEIDON_HASH_OUT_LEN..1 + 2 * POSEIDON_HASH_OUT_LEN],
+        );
+        let private_commitment = PoseidonHashOutTarget::from_slice(
+            &slice[1 + 2 * POSEIDON_HASH_OUT_LEN..1 + 3 * POSEIDON_HASH_OUT_LEN],
+        );
+        Self {
+            use_allow_list,
+            allow_list_tree_root,
+            deny_list_tree_root,
+            private_commitment,
+        }
+    }
+
+    pub fn from_pis(pis: &[Target]) -> Self {
+        Self::from_slice(&pis[0..INNOCENCE_WRAP_PUBLIC_INPUTS_LEN])
+    }
+}
+
+pub struct InnocenceWrapCircuit<F, C, const D: usize>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+{
+    innocence_proof: ProofWithPublicInputsTarget<D>,
+    private_state: PrivateStateTarget,
+    data: CircuitData<F, C, D>,
+}
+
+impl<F, C, const D: usize> InnocenceWrapCircuit<F, C, D>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F> + 'static,
+    C::Hasher: AlgebraicHasher<F>,
+{
+    pub fn new(verifier_data: &VerifierCircuitData<F, C, D>) -> Self {
+        let mut builder =
+            CircuitBuilder::<F, D>::new(CircuitConfig::standard_recursion_zk_config());
+
+        let private_state = PrivateStateTarget::new(&mut builder);
+        let innocence_proof = add_proof_target_and_verify_cyclic(verifier_data, &mut builder);
+        let innocence_pis = InnocencePublicInputsTarget::from_pis(&innocence_proof.public_inputs);
+        private_state
+            .nullifier_tree_root
+            .connect(&mut builder, innocence_pis.nullifier_tree_root);
+        let private_commitment = private_state.commitment(&mut builder);
+        let pis = InnocenceWrapPublicInputsTarget {
+            use_allow_list: innocence_pis.use_allow_list,
+            allow_list_tree_root: innocence_pis.allow_list_tree_root,
+            deny_list_tree_root: innocence_pis.deny_list_tree_root,
+            private_commitment,
+        };
+        builder.register_public_inputs(&pis.to_vec());
+        let data = builder.build();
+        Self {
+            innocence_proof,
+            private_state,
+            data,
+        }
+    }
+
+    pub fn prove(
+        &self,
+        innocence_proof: &ProofWithPublicInputs<F, C, D>,
+        private_state: PrivateState,
+    ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
+        let mut pw = PartialWitness::<F>::new();
+        pw.set_proof_with_pis_target(&self.innocence_proof, innocence_proof);
+        self.private_state.set_witness(&mut pw, &private_state);
+        self.data.prove(pw)
+    }
+}

--- a/src/circuits/proof_of_innocence/mod.rs
+++ b/src/circuits/proof_of_innocence/mod.rs
@@ -1,3 +1,4 @@
 pub mod address_list;
 pub mod innocence_circuit;
 pub mod innocence_inner_target;
+pub mod innocence_wrap_circuit;

--- a/src/circuits/proof_of_innocence/mod.rs
+++ b/src/circuits/proof_of_innocence/mod.rs
@@ -1,3 +1,3 @@
 pub mod address_list;
 pub mod innocence_circuit;
-pub mod innocence_inner_circuit;
+pub mod innocence_inner_target;

--- a/src/circuits/proof_of_innocence/mod.rs
+++ b/src/circuits/proof_of_innocence/mod.rs
@@ -1,2 +1,3 @@
-pub mod innocence_circuit;
 pub mod address_list;
+pub mod innocence_circuit;
+pub mod innocence_inner_circuit;

--- a/src/circuits/proof_of_innocence/mod.rs
+++ b/src/circuits/proof_of_innocence/mod.rs
@@ -1,0 +1,2 @@
+pub mod innocence_circuit;
+pub mod address_list;

--- a/src/circuits/proof_of_innocence/mod.rs
+++ b/src/circuits/proof_of_innocence/mod.rs
@@ -1,4 +1,5 @@
 pub mod address_list;
 pub mod innocence_circuit;
 pub mod innocence_inner_target;
+pub mod innocence_processor;
 pub mod innocence_wrap_circuit;

--- a/src/common/generic_address.rs
+++ b/src/common/generic_address.rs
@@ -123,6 +123,19 @@ impl GenericAddressTarget {
         }
     }
 
+    pub fn from_address<F: RichField + Extendable<D>, const D: usize>(
+        builder: &mut CircuitBuilder<F, D>,
+        address: AddressTarget,
+    ) -> Self {
+        let mut limbs = address.to_vec();
+        let zero = builder.zero();
+        limbs.resize(U256_LEN, zero);
+        Self {
+            is_pubkey: builder._false(),
+            data: U256Target::from_slice(&limbs),
+        }
+    }
+
     pub fn to_address<F: RichField + Extendable<D>, const D: usize>(
         &self,
         builder: &mut CircuitBuilder<F, D>,

--- a/src/common/trees/nullifier_tree.rs
+++ b/src/common/trees/nullifier_tree.rs
@@ -45,6 +45,7 @@ impl NullifierTree {
         self.0
             .leaves()
             .iter()
+            .skip(1) // ignore the default leaf
             .map(|l| Bytes32::from_u32_slice(&l.key.to_u32_vec()))
             .collect()
     }

--- a/src/common/trees/nullifier_tree.rs
+++ b/src/common/trees/nullifier_tree.rs
@@ -41,6 +41,14 @@ impl NullifierTree {
         self.0.get_root()
     }
 
+    pub fn nullifiers(&self) -> Vec<Bytes32> {
+        self.0
+            .leaves()
+            .iter()
+            .map(|l| Bytes32::from_u32_slice(&l.key.to_u32_vec()))
+            .collect()
+    }
+
     pub fn prove_and_insert(&mut self, nullifier: Bytes32) -> Result<NullifierInsertionProof> {
         let proof = self
             .0

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -9,5 +9,6 @@ pub const SENDER_TREE_HEIGHT: usize = TX_TREE_HEIGHT;
 pub const NUM_SENDERS_IN_BLOCK: usize = 1 << TX_TREE_HEIGHT;
 pub const NUM_TRANSFERS_IN_TX: usize = 1 << TRANSFER_TREE_HEIGHT;
 pub const ACCOUNT_TREE_HEIGHT: usize = ACCOUNT_ID_BITS;
+pub const ADDRESS_LIST_TREE_HEIGHT: usize = 32;
 
 pub(crate) const CYCLIC_CIRCUIT_PADDING_DEGREE: usize = 13;

--- a/src/utils/hash_chain/cyclic_chain_circuit.rs
+++ b/src/utils/hash_chain/cyclic_chain_circuit.rs
@@ -57,7 +57,7 @@ where
         let hash = Bytes32Target::from_slice(&inner_proof.public_inputs[BYTES32_LEN..]);
         builder.register_public_inputs(&hash.to_vec());
 
-        let common_data = common_data_for_circuit::<F, C, D>();
+        let common_data = common_data_for_hash_chain_circuit::<F, C, D>();
         let verifier_data_target = builder.add_verifier_data_public_inputs();
 
         let prev_proof = builder.add_virtual_proof_with_pis(&common_data);
@@ -108,7 +108,7 @@ where
 }
 
 // Generates `CommonCircuitData` for the cyclic circuit
-fn common_data_for_circuit<
+fn common_data_for_hash_chain_circuit<
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
     const D: usize,

--- a/src/utils/trees/indexed_merkle_tree/membership.rs
+++ b/src/utils/trees/indexed_merkle_tree/membership.rs
@@ -1,6 +1,6 @@
 use anyhow::{ensure, Result};
 use plonky2::{
-    field::extension::Extendable,
+    field::{extension::Extendable, types::Field},
     hash::hash_types::RichField,
     iop::{
         target::{BoolTarget, Target},
@@ -128,7 +128,7 @@ impl MembershipProofTarget {
         }
     }
 
-    pub fn set_witness<F: RichField, W: WitnessWrite<F>>(
+    pub fn set_witness<F: Field, W: WitnessWrite<F>>(
         &self,
         witness: &mut W,
         value: &MembershipProof,

--- a/src/utils/trees/indexed_merkle_tree/mod.rs
+++ b/src/utils/trees/indexed_merkle_tree/mod.rs
@@ -94,6 +94,10 @@ impl IndexedMerkleTree {
         Ok(())
     }
 
+    pub fn leaves(&self) -> Vec<IndexedMerkleLeaf> {
+        self.0.leaves()
+    }
+
     pub fn len(&self) -> usize {
         self.0.len()
     }


### PR DESCRIPTION
I have implemented "proof of innocence."

A proof can only be generated for an account if the following conditions are met:

- The account has not received funds through any transactions other than deposits.
- (When an allow_list is specified) All deposit addresses must be included in the allow_list.
- None of the deposit addresses are included in the deny_list.