### PR TITLE
ci(example): add simple_proof stub to verify nightly build

### DIFF
--- a/examples/simple_proof.rs
+++ b/examples/simple_proof.rs
@@ -1,0 +1,9 @@
+//! Compile-only stub to verify intmax2-zkp builds under nightly.
+
+extern crate intmax2_zkp;
+
+fn main() {
+    // Just proving the library builds—no further API assumptions.
+    println!(" intmax2-zkp builds cleanly under nightly!");
+}
+


### PR DESCRIPTION
**What**  
Adds a minimal compile-only example stub at `examples/simple_proof.rs` that simply verifies the `intmax2-zkp` crate builds cleanly under the nightly Rust toolchain.

**Why**  
The zero-knowledge dependencies (e.g. `plonky2`) use nightly-only features like `specialization`. By running this stub in CI on every PR, we’ll catch any nightly-specific breakages early, before they propagate to downstream examples or consumers.

**Changes**  
- Created `examples/simple_proof.rs`  
- Prints a confirmation message when built and run under nightly  

**Next Steps**  
- Expand this stub into a full end-to-end “proof + verify” demo  
- Wire up a real `BlockData` example and invoke `ValidityCircuit::new`  
- Add CI checks to run the fully fleshed-out example once ready
